### PR TITLE
fix: single-flight去重key从文件URL改为内容SHA-256哈希

### DIFF
--- a/admin/src/main/java/com/hewei/hzyjy/xunzhi/interview/flow/extraction/InterviewQuestionExtractionService.java
+++ b/admin/src/main/java/com/hewei/hzyjy/xunzhi/interview/flow/extraction/InterviewQuestionExtractionService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -53,6 +54,9 @@ public class InterviewQuestionExtractionService {
         reqDTO.setAgentId(agentProperties.getId());
         response.setIsSuccess(0);
 
+        // 哈希计算是纯本地操作，在获取分布式锁之前完成，减少锁占用时间。
+        String resumeContentHash = computeResumeHash(reqDTO.getResumePdf(), reqDTO.getSessionId());
+
         RLock heavyLock = null;
         long startTime = System.currentTimeMillis();
         try {
@@ -74,7 +78,7 @@ public class InterviewQuestionExtractionService {
                     agentProperties,
                     fileUrl,
                     InterviewAiGuardStage.INTERVIEW_EXTRACTION,
-                    interviewAiInvoker.buildSingleFlightKey(InterviewAiGuardStage.INTERVIEW_EXTRACTION, reqDTO.getSessionId(), fileUrl)
+                    interviewAiInvoker.buildSingleFlightKey(InterviewAiGuardStage.INTERVIEW_EXTRACTION, reqDTO.getSessionId(), resumeContentHash)
             );
 
             long responseTime = System.currentTimeMillis() - startTime;
@@ -304,6 +308,31 @@ public class InterviewQuestionExtractionService {
 
     private List<String> normalizeStringList(Object value) {
         return interviewResponseParser.asStringList(value);
+    }
+
+    /**
+     * 计算简历文件内容的 SHA-256 哈希，用于 single-flight 去重。
+     * 相同文件内容产生相同哈希，避免因上传 URL 每次变化导致去重失效。
+     *
+     * @param resumePdf 简历文件
+     * @param sessionId 会话标识，仅用于日志
+     * @return 文件内容的 SHA-256 十六进制字符串，文件为空时返回 null
+     */
+    private String computeResumeHash(MultipartFile resumePdf, String sessionId) {
+        if (resumePdf == null || resumePdf.isEmpty()) {
+            log.debug("Resume PDF is null or empty, cannot compute content hash, sessionId={}", sessionId);
+            return null;
+        }
+        try {
+            byte[] fileBytes = resumePdf.getBytes();
+            String hash = DigestUtil.sha256Hex(fileBytes);
+            log.debug("Computed resume content hash, sessionId={}, hash={}", sessionId, hash);
+            return hash;
+        } catch (Exception e) {
+            log.warn("Failed to read resume PDF bytes for content hashing, sessionId={}, error={}",
+                    sessionId, e.getMessage());
+            return null;
+        }
     }
 
     private String digestForLog(String value) {


### PR DESCRIPTION
#9 
## 改动摘要

- 修复面试题目抽取 SingleFlight 去重 key 使用上传 URL（每次不同）导致去重失效的问题，改为使用简历文件内容的 SHA-256 哈希作为去重key。

## 为什么需要这次改动

-之前 buildSingleFlightKey 使用星辰平台返回的 fileUrl 作为 SingleFlight key 的一部分。但每次上传同一个简历文件，星辰平台返回的URL 可能不同，导致：

  1. 同一份简历并发抽取时，SingleFlight 无法去重 — 两个请求上传同一份 PDF，得到两个不同的 fileUrl，SingleFlight key
  不同，各自独立调用 AI，浪费资源
  2. 极端情况下可能重复扣费或超限

  改为文件内容哈希后，相同内容 → 相同 key → 正确去重。

## 测试方式
- [x] `./mvnw -B -ntp clean compile -DskipTests`
 - [x] `./mvnw -B -ntp clean verify`
 - [x] 手动验证：同一份简历文件并发请求分别发送到两台服务器，确认后续请求命中 Single-flight 缓存，不会重复调用 AI

## 风险与回滚点

- 低风险：仅修改 SingleFlight key 的计算方式，不改变业务逻辑和数据结构
- 兼容性：computeResumeHash 在文件为空时返回 null，此时 buildSingleFlightKey 的行为与之前传 null 一致（由 buildSingleFlightKey内部处理），不会因空文件导致 NPE
- 回滚：将 buildSingleFlightKey(...) 第三个参数从 resumeContentHash 改回 fileUrl 即可

## 关联文档 / 截图 / 响应示例

<img width="2784" height="1799" alt="屏幕截图 2026-06-15 173541" src="https://github.com/user-attachments/assets/e90ed9b5-2a12-47e3-84fc-7eb2b1220fee" />
<img width="1257" height="703" alt="屏幕截图 2026-06-15 173724" src="https://github.com/user-attachments/assets/2af5ce8a-a8da-46eb-a660-fd80f8e89ba0" />


