### PR TITLE
Fix/runtime rehydrate lock check

### DIFF
--- a/admin/src/main/java/com/hewei/hzyjy/xunzhi/interview/application/runtime/InterviewSessionRuntimeRehydrateService.java
+++ b/admin/src/main/java/com/hewei/hzyjy/xunzhi/interview/application/runtime/InterviewSessionRuntimeRehydrateService.java
@@ -85,6 +85,14 @@ public class InterviewSessionRuntimeRehydrateService {
             if (isRuntimeReady(sessionId, resolvedScope)) {
                 return buildView(loadMode, InterviewRuntimeRestoreSource.CACHE, InterviewRuntimeConfidence.EXACT, false, getRuntimeSnapshot(sessionId));
             }
+            if (lock == null) {
+                log.warn(
+                "Failed to acquire runtime rehydrate lock after waiting, sessionId={}",
+                sessionId);
+
+                return buildView(
+                loadMode, InterviewRuntimeRestoreSource.NONE, InterviewRuntimeConfidence.READ_ONLY, false, getRuntimeSnapshot(sessionId));
+            }
             InterviewSessionRuntimeView rebuilt = rebuildRuntime(sessionId, loadMode, resolvedScope);
             if (rebuilt != null) {
                 return rebuilt;

--- a/admin/src/test/java/com/hewei/hzyjy/xunzhi/interview/application/runtime/InterviewSessionRuntimeRehydrateServiceTest.java
+++ b/admin/src/test/java/com/hewei/hzyjy/xunzhi/interview/application/runtime/InterviewSessionRuntimeRehydrateServiceTest.java
@@ -1,0 +1,104 @@
+package com.hewei.hzyjy.xunzhi.interview.application.runtime;
+
+import com.hewei.hzyjy.xunzhi.interview.dao.mapper.InterviewRecordMapper;
+import com.hewei.hzyjy.xunzhi.interview.service.InterviewQuestionCacheService;
+import com.hewei.hzyjy.xunzhi.interview.service.InterviewQuestionService;
+import com.hewei.hzyjy.xunzhi.interview.service.InterviewSessionService;
+import com.hewei.hzyjy.xunzhi.interview.service.model.InterviewRuntimeConfidence;
+import com.hewei.hzyjy.xunzhi.interview.service.model.InterviewRuntimeLoadMode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InterviewSessionRuntimeRehydrateServiceTest {
+
+    @Mock
+    private InterviewSessionRuntimeSnapshotService runtimeSnapshotService;
+
+    @Mock
+    private InterviewSessionRuntimeLockService runtimeLockService;
+
+    @Mock
+    private InterviewSessionService interviewSessionService;
+
+    @Mock
+    private InterviewQuestionService interviewQuestionService;
+
+    @Mock
+    private InterviewQuestionCacheService interviewQuestionCacheService;
+
+    @Mock
+    private InterviewRecordMapper interviewRecordMapper;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
+
+    private InterviewSessionRuntimeRehydrateService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new InterviewSessionRuntimeRehydrateService(
+                runtimeSnapshotService,
+                runtimeLockService,
+                interviewSessionService,
+                interviewQuestionService,
+                interviewQuestionCacheService,
+                interviewRecordMapper,
+                stringRedisTemplate
+        );
+    }
+
+    @Test
+    void shouldNotRebuildRuntimeWhenRehydrateLockCannotBeAcquired() throws InterruptedException {
+        String sessionId = "session-1";
+
+        when(stringRedisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.size(anyString())).thenReturn(0L);
+        when(runtimeLockService.acquire(sessionId)).thenReturn(null);
+        when(runtimeLockService.acquire(sessionId, 80L)).thenReturn(null);
+        when(runtimeSnapshotService.findSnapshot(sessionId)).thenReturn(Optional.empty());
+
+        InterviewSessionRuntimeView result = service.ensureRuntime(
+                sessionId,
+                InterviewRuntimeLoadMode.READ_WRITE_REQUIRED,
+                InterviewRuntimeRehydrateScope.FULL_RUNTIME
+        );
+
+        assertAll(
+                () -> assertEquals(InterviewRuntimeLoadMode.READ_WRITE_REQUIRED, result.getLoadMode()),
+                () -> assertEquals(InterviewRuntimeRestoreSource.NONE, result.getRestoreSource()),
+                () -> assertEquals(InterviewRuntimeConfidence.READ_ONLY, result.getConfidence()),
+                () -> assertFalse(result.isCacheRebuilt()),
+                () -> assertFalse(result.canWrite()),
+                () -> assertNull(result.getSnapshot())
+        );
+
+        verify(runtimeLockService).acquire(sessionId);
+        verify(runtimeLockService).acquire(sessionId, 80L);
+        verify(runtimeLockService).release(isNull());
+        verify(interviewRecordMapper, never()).selectOne(any());
+        verify(interviewSessionService, never()).getBySessionId(anyString());
+        verify(interviewQuestionService, never()).getBySessionId(anyString());
+    }
+}


### PR DESCRIPTION
## 改动摘要

- 在运行态恢复流程中增加 rehydrate 锁获取结果检查。
- 当等待后仍未获取到锁时，由继续重建改为降级返回。

## 为什么需要这次改动

- 当前流程在等待 rehydrate 锁后，即使仍未成功获取锁，也会继续执行运行态重建。

这可能导致多个请求在没有互斥保护的情况下同时重建同一个面试会话，产生重复重建、缓存覆盖或运行态不一致的问题。

本次修改确保只有成功获取 rehydrate 锁的请求才能执行重建；未获取到锁的请求返回 `NONE / READ_ONLY` 结果，避免无锁写入。

## 测试方式

- ## 测试方式

- [x] `InterviewSessionRuntimeRehydrateServiceTest`
  - 验证两次获取 rehydrate 锁失败时不会继续重建运行态
  - 验证返回 `NONE / READ_ONLY`
  - 验证结果不可写且 `cacheRebuilt=false`
  - 结果：Tests run: 1, Failures: 0, Errors: 0
 
- [ ] `./mvnw -B -ntp clean verify`
  - 当前 Surefire `@{argLine}` 配置存在启动问题，尚未完成全量验证

- [ ] 手动验证关键接口或页面

## 风险与回滚点

- 修改仅影响“运行态未就绪且等待后仍未获取到 rehydrate 锁”的降级路径。
- 正常获取锁和缓存已经就绪的路径不受影响。
- 锁竞争严重时，请求可能得到只读降级结果，而不是立即触发重建。
- 如需回滚，可撤销本 PR 对 `InterviewSessionRuntimeRehydrateService` 的锁判空逻辑。

## 关联文档 / 截图 / 响应示例

- 本次修改不涉及接口格式和 UI，无需截图。

## 关联 Issue
Closes lishuangqiang/AI-Meeting#12
